### PR TITLE
chore: multi-arch hardening in release workflow and add lint

### DIFF
--- a/.github/workflows/dockerfile-lint.yml
+++ b/.github/workflows/dockerfile-lint.yml
@@ -1,0 +1,11 @@
+name: Dockerfile Multi-Arch Lint
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  lint:
+    permissions:
+      contents: read
+    uses: antinvestor/common/.github/workflows/dockerfile-lint.yml@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,20 @@ jobs:
             type=sha
             type=sha,format=long
 
+      # Honor per-Dockerfile `# build-platforms:` opt-out comment.
+      # Mirrors the parsing in common/.github/workflows/docker-release.yml.
+      - name: Determine build platforms
+        id: platforms
+        run: |
+          DOCKERFILE="./${{ env.APP_PATH }}/Dockerfile"
+          HINT=$(grep -m1 -E '^# build-platforms:' "$DOCKERFILE" 2>/dev/null | sed -E 's/^# build-platforms:[[:space:]]*//')
+          if [[ -n "$HINT" ]]; then
+            echo "Using per-Dockerfile platforms hint: $HINT"
+            echo "value=$HINT" >> $GITHUB_OUTPUT
+          else
+            echo "value=linux/amd64,linux/arm64" >> $GITHUB_OUTPUT
+          fi
+
       # Push to Github Container Registry
       - name: Build and Push Image to Github Container Registry
         uses: docker/build-push-action@v7
@@ -102,7 +116,7 @@ jobs:
           context: ./
           file: ./${{ env.APP_PATH }}/Dockerfile
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ steps.platforms.outputs.value }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |


### PR DESCRIPTION
## Summary

- Patches `.github/workflows/release.yml` to honor per-Dockerfile `# build-platforms:` opt-out comments. Mirrors the parsing logic in `antinvestor/common/.github/workflows/docker-release.yml` so per-app Dockerfile opt-outs are consistent org-wide. Default unchanged: `linux/amd64,linux/arm64`.
- Adds `.github/workflows/dockerfile-lint.yml` caller for the shared multi-arch lint workflow.

## Test plan

- [ ] `dockerfile-lint` job passes (verified locally — all builder Dockerfiles follow the canonical pattern).
- [ ] Existing CI continues to pass.
- [ ] On next release tag, multi-arch images (`linux/amd64` + `linux/arm64`) still get built for all `apps/*/Dockerfile`s; if a Dockerfile ever opts out via `# build-platforms:`, it is honored.

## Context

Part of a cross-repo rollout adding a CI lint guard for multi-arch Docker builds. See https://github.com/antinvestor/common/pull/4 for the reusable workflow and lint script.