### PR TITLE
chore(deps): migrate to frame v1.96.0 + natspubsub v0.8.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.26.1
 require (
 	github.com/boundaryml/baml v0.222.0
 	github.com/docker/docker v28.5.2+incompatible
-	github.com/pitabwire/frame v1.95.0
+	github.com/pitabwire/frame v1.96.0
 	github.com/pitabwire/util v0.9.0
 	github.com/redis/go-redis/v9 v9.19.0
 	github.com/rs/xid v1.6.0
@@ -59,7 +59,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0 // indirect
 	github.com/panjf2000/ants/v2 v2.12.0 // indirect
-	github.com/pitabwire/natspubsub v0.8.3 // indirect
+	github.com/pitabwire/natspubsub v0.8.4 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.23.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -171,10 +171,10 @@ github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0 h1:huZxe
 github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0/go.mod h1:c2UboItfGpqIzXoXlxBRMCp3rQqO+Wx2ecsH25jcWxU=
 github.com/panjf2000/ants/v2 v2.12.0 h1:u9JhESo83i/GkZnhfTNuFMMWcNt7mnV1bGJ6FT4wXH8=
 github.com/panjf2000/ants/v2 v2.12.0/go.mod h1:tSQuaNQ6r6NRhPt+IZVUevvDyFMTs+eS4ztZc52uJTY=
-github.com/pitabwire/frame v1.95.0 h1:DfQ85WyPaRnFDSlN/IWsjJc8zBIeciiUjxNVEbqW338=
-github.com/pitabwire/frame v1.95.0/go.mod h1:VgKY5c3wGtl4ij4iIwUB3EdSXPPyV0Xj+PacmRIN38s=
-github.com/pitabwire/natspubsub v0.8.3 h1:VFc73S+qBgxKDgD1ZW6Hz/wKu/8ao/uA1JG38a7MWfc=
-github.com/pitabwire/natspubsub v0.8.3/go.mod h1:W5FT+Am26dmKAKYtMsKQfEeqEUi7O16bpl0UTFlQEA0=
+github.com/pitabwire/frame v1.96.0 h1:99oLHTXAGeJVelOV24XaeOodjSD7lb5xG82MY8heN38=
+github.com/pitabwire/frame v1.96.0/go.mod h1:1g8nT+Atfp0thB4yC3iuIBUhvRxXmsKbih39SYbEsmo=
+github.com/pitabwire/natspubsub v0.8.4 h1:iXncMM/Fuvmyu3+VFDazOxKf5M3AWNQZdvLpM+NtKZ0=
+github.com/pitabwire/natspubsub v0.8.4/go.mod h1:h2S81+ro+eB1NeWWDbhK4EkEN/A72o7hnrDXTUq67Js=
 github.com/pitabwire/util v0.9.0 h1:fnlTAuWKqAjc6GalO+a7hMeo6g3fAv5yjmaP237ChP4=
 github.com/pitabwire/util v0.9.0/go.mod h1:JrLiS3K4VXsLZE38LLvq1N0X2j0fs33QLz/zMXf3zc4=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=


### PR DESCRIPTION
## Summary

- Bumps `github.com/pitabwire/frame` to **v1.96.0** (pluggable tenancy/RLS).
- Bumps `github.com/pitabwire/natspubsub` to **v0.8.4**.
- Removes manual `connectInterceptors.NewTenancyTxInterceptor(dbPool)` wiring where present — v1.96.0's `DefaultList` now auto-includes `tenancy.NewClaimsInterceptor()`.
- (service-fintech only) Removes `datastore/scopes` usages; RLS now enforces tenancy at the connection-acquire layer. Cross-tenant reapers/archival use `tenancy.WithSkipEnforcement(ctx)`.

## Frame v1.96.0 breaking changes
- Removed `Pool.WithTenancy`, `Pool.WithRequestTx`, `ContextWithTx`, `TxFromContext`.
- Removed `NewTenancyTxInterceptor` (auto-included now).
- Removed `datastore/scopes` package — RLS replaces it.
- New `tenancy/` package: `Claims`, `Provider`, `WithExtraPartitions`, `WithSkipEnforcement`, `NewClaimsInterceptor`.
- New `datastore/dialect/` abstraction.

## Operational note
**Postgres superuser bypasses RLS** even with `FORCE` — services must connect with a non-superuser role in production. See `frame/docs/datastore.md`.

## Test plan
- [ ] CI green
- [ ] Verify production DB role is non-superuser without `BYPASSRLS`